### PR TITLE
Ability to disable validate Accept header

### DIFF
--- a/src/Anemonis.AspNetCore.JsonRpc.UnitTests/JsonRpcMiddlewareTests.cs
+++ b/src/Anemonis.AspNetCore.JsonRpc.UnitTests/JsonRpcMiddlewareTests.cs
@@ -196,8 +196,11 @@ namespace Anemonis.AspNetCore.JsonRpc.UnitTests
             Assert.AreEqual(StatusCodes.Status406NotAcceptable, httpContext.Response.StatusCode);
         }
 
-        [TestMethod]
-        public async Task InvokeAsyncWhenAcceptHeaderIsNotSpecifiedButIgnoreEmptyAcceptHeaderIsEnabled()
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("application/xml")]
+        [DataRow("text/plain")]
+        public async Task InvokeAsyncWhenIgnoreEmptyAcceptHeaderIsEnabled(string mediaType)
         {
             var serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
 
@@ -220,6 +223,11 @@ namespace Anemonis.AspNetCore.JsonRpc.UnitTests
 
             httpContext.Request.Method = HttpMethods.Post;
             httpContext.Request.ContentType = "application/json; charset=utf-8";
+
+            if (mediaType != null)
+            {
+                httpContext.Request.Headers.Add(HeaderNames.Accept, mediaType);
+            }
 
             await jsonRpcMiddleware.InvokeAsync(httpContext, c => Task.CompletedTask);
 

--- a/src/Anemonis.AspNetCore.JsonRpc/JsonRpcMiddleware`1.cs
+++ b/src/Anemonis.AspNetCore.JsonRpc/JsonRpcMiddleware`1.cs
@@ -140,7 +140,7 @@ namespace Anemonis.AspNetCore.JsonRpc
                 return;
             }
 
-            if (_options.ValidateAcceptHeader)
+            if (!_options.IgnoreEmptyAcceptHeader)
             {
                 if (!context.Request.Headers.TryGetValue(HeaderNames.Accept, out var acceptTypeHeaderValueString))
                 {
@@ -156,8 +156,7 @@ namespace Anemonis.AspNetCore.JsonRpc
                     return;
                 }
 
-                if (!acceptTypeHeaderValue.MediaType.Equals(MediaTypes.Any, StringComparison.OrdinalIgnoreCase) &&
-                    !acceptTypeHeaderValue.MediaType.Equals(MediaTypes.ApplicationJson, StringComparison.OrdinalIgnoreCase))
+                if (!acceptTypeHeaderValue.MediaType.Equals(MediaTypes.ApplicationJson, StringComparison.OrdinalIgnoreCase))
                 {
                     context.Response.StatusCode = StatusCodes.Status406NotAcceptable;
 

--- a/src/Anemonis.AspNetCore.JsonRpc/JsonRpcMiddleware`1.cs
+++ b/src/Anemonis.AspNetCore.JsonRpc/JsonRpcMiddleware`1.cs
@@ -46,11 +46,19 @@ namespace Anemonis.AspNetCore.JsonRpc
             {
                 throw new ArgumentNullException(nameof(services));
             }
+            if (environment == null)
+            {
+                throw new ArgumentNullException(nameof(environment));
+            }
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
 
-            _environment = environment ?? throw new ArgumentNullException(nameof(environment));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _environment = environment;
+            _logger = logger;
 
-            _options = services.GetService<IOptions<JsonRpcOptions>>()?.Value ?? JsonRpcOptions.CreateDefault();
+            _options = services.GetService<IOptions<JsonRpcOptions>>()?.Value ?? new JsonRpcOptions();
             _handler = services.GetService<T>() ?? ActivatorUtilities.CreateInstance<T>(services);
 
             _serializer = new JsonRpcSerializer(CreateJsonRpcContractResolver(_handler), _options.JsonSerializer);

--- a/src/Anemonis.AspNetCore.JsonRpc/JsonRpcMiddleware`1.cs
+++ b/src/Anemonis.AspNetCore.JsonRpc/JsonRpcMiddleware`1.cs
@@ -148,9 +148,11 @@ namespace Anemonis.AspNetCore.JsonRpc
                 return;
             }
 
-            if (!_options.IgnoreEmptyAcceptHeader)
+            var hasAcceptHeader = context.Request.Headers.TryGetValue(HeaderNames.Accept, out var acceptTypeHeaderValueString);
+
+            if (!_options.IgnoreEmptyAcceptHeader || hasAcceptHeader)
             {
-                if (!context.Request.Headers.TryGetValue(HeaderNames.Accept, out var acceptTypeHeaderValueString))
+                if (!hasAcceptHeader)
                 {
                     context.Response.StatusCode = StatusCodes.Status406NotAcceptable;
 

--- a/src/Anemonis.AspNetCore.JsonRpc/JsonRpcOptions.cs
+++ b/src/Anemonis.AspNetCore.JsonRpc/JsonRpcOptions.cs
@@ -20,7 +20,7 @@ namespace Anemonis.AspNetCore.JsonRpc
         }
 
         /// <summary>
-        /// By default HTTP Accept header is required and only 'application/json' is valid, with this option Middleware disable any validation for Accept header
+        /// By default HTTP Accept header is required and only 'application/json' is valid, IgnoreEmptyAcceptHeader allows you to omit Accept header
         /// </summary>
         public bool IgnoreEmptyAcceptHeader
         {

--- a/src/Anemonis.AspNetCore.JsonRpc/JsonRpcOptions.cs
+++ b/src/Anemonis.AspNetCore.JsonRpc/JsonRpcOptions.cs
@@ -19,8 +19,8 @@ namespace Anemonis.AspNetCore.JsonRpc
             set;
         }
 
-        /// <summary>Gets or sets the VerifyAcceptHeader attribute used for validate HTTP Accept header.</summary>
-        public bool ValidateAcceptHeader
+        /// <summary>Gets or sets the IgnoreEmptyAcceptHeader attribute used for disable validation HTTP Accept header.</summary>
+        public bool IgnoreEmptyAcceptHeader
         {
             get;
             set;
@@ -28,10 +28,7 @@ namespace Anemonis.AspNetCore.JsonRpc
 
         internal static JsonRpcOptions CreateDefault()
         {
-            return new JsonRpcOptions()
-            {
-                ValidateAcceptHeader = true
-            };
+            return new JsonRpcOptions();
         }
     }
 }

--- a/src/Anemonis.AspNetCore.JsonRpc/JsonRpcOptions.cs
+++ b/src/Anemonis.AspNetCore.JsonRpc/JsonRpcOptions.cs
@@ -18,5 +18,20 @@ namespace Anemonis.AspNetCore.JsonRpc
             get;
             set;
         }
+
+        /// <summary>Gets or sets the VerifyAcceptHeader attribute used for validate HTTP Accept header.</summary>
+        public bool ValidateAcceptHeader
+        {
+            get;
+            set;
+        }
+
+        internal static JsonRpcOptions CreateDefault()
+        {
+            return new JsonRpcOptions()
+            {
+                ValidateAcceptHeader = true
+            };
+        }
     }
 }

--- a/src/Anemonis.AspNetCore.JsonRpc/JsonRpcOptions.cs
+++ b/src/Anemonis.AspNetCore.JsonRpc/JsonRpcOptions.cs
@@ -19,16 +19,13 @@ namespace Anemonis.AspNetCore.JsonRpc
             set;
         }
 
-        /// <summary>Gets or sets the IgnoreEmptyAcceptHeader attribute used for disable validation HTTP Accept header.</summary>
+        /// <summary>
+        /// By default HTTP Accept header is required and only 'application/json' is valid, with this option Middleware disable any validation for Accept header
+        /// </summary>
         public bool IgnoreEmptyAcceptHeader
         {
             get;
             set;
-        }
-
-        internal static JsonRpcOptions CreateDefault()
-        {
-            return new JsonRpcOptions();
         }
     }
 }

--- a/src/Anemonis.AspNetCore.JsonRpc/MediaTypes.cs
+++ b/src/Anemonis.AspNetCore.JsonRpc/MediaTypes.cs
@@ -5,6 +5,5 @@ namespace Anemonis.AspNetCore.JsonRpc
     internal static class MediaTypes
     {
         public const string ApplicationJson = "application/json";
-        public const string Any = "*/*";
     }
 }

--- a/src/Anemonis.AspNetCore.JsonRpc/MediaTypes.cs
+++ b/src/Anemonis.AspNetCore.JsonRpc/MediaTypes.cs
@@ -5,5 +5,6 @@ namespace Anemonis.AspNetCore.JsonRpc
     internal static class MediaTypes
     {
         public const string ApplicationJson = "application/json";
+        public const string Any = "*/*";
     }
 }


### PR DESCRIPTION
### Summary
It would be great to add the option to disable Accept header validation. 

```StatusCodes.Status406NotAcceptable``` - is a tangible breaking change when migration from another JSON Rpc library.

Also added by default verifying that Accept header is not equal ```* / *``` and only then check ```application/json``` - for the cases where client can parse any types.

### Changes

- Added JsonRpcOptions property ```ValidateAcceptHeader```, which enabled by default. When disabled - middleware skip validation related to Accept header
- Added verifying that Accept header is not equal ```* / *``` and only then check ```application/json```

### Outcome

Becnchmarks before:
```
BenchmarkDotNet=v0.12.0, OS=Windows 10.0.14393.3274 (1607/AnniversaryUpdate/Redstone1)
Intel Core i5-6400 CPU 2.70GHz (Skylake), 1 CPU, 4 logical and 4 physical cores
Frequency=2648431 Hz, Resolution=377.5820 ns, Timer=TSC
.NET Core SDK=3.0.100
  [Host] : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), X64 RyuJIT DEBUG

Toolchain=InProcessEmitToolchain  IterationTime=250.0000 ms  MaxIterationCount=20  
MinIterationCount=15  WarmupCount=1  

|                 Method |         Mean |       Error |      StdDev |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |-------------:|------------:|------------:|--------:|------:|------:|----------:|
| TYPE=H-CASE=B0T0P0E0D0 |   6,571.8 ns |    369.4 ns |    425.4 ns |  2.0749 |     - |     - |    6528 B |
| TYPE=H-CASE=B0T0P0E1D0 |  11,327.2 ns |    784.6 ns |    903.5 ns |  4.2464 |     - |     - |   13320 B |
| TYPE=H-CASE=B0T0P0E1D1 |  10,052.2 ns |    477.3 ns |    549.7 ns |  4.2814 |     - |     - |   13432 B |
| TYPE=H-CASE=B0T0P1E0D0 |   7,286.5 ns |    211.5 ns |    235.0 ns |  2.2641 |     - |     - |    7128 B |
| TYPE=H-CASE=B0T0P1E1D0 |  11,385.1 ns |    219.1 ns |    234.5 ns |  4.4298 |     - |     - |   13920 B |
| TYPE=H-CASE=B0T0P1E1D1 |  12,204.7 ns |    535.7 ns |    616.9 ns |  4.4265 |     - |     - |   14032 B |
| TYPE=H-CASE=B0T0P2E0D0 |   7,497.6 ns |    149.3 ns |    146.6 ns |  2.3667 |     - |     - |    7456 B |
| TYPE=H-CASE=B0T0P2E1D0 |  11,847.3 ns |    259.2 ns |    298.5 ns |  4.5192 |     - |     - |   14248 B |
| TYPE=H-CASE=B0T0P2E1D1 |  12,296.9 ns |    240.3 ns |    276.7 ns |  4.5419 |     - |     - |   14360 B |
| TYPE=H-CASE=B0T1P0E0D0 |   9,257.9 ns |    244.5 ns |    251.1 ns |  4.2170 |     - |     - |   13232 B |
| TYPE=H-CASE=B0T1P0E1D0 |  10,648.7 ns |  1,052.5 ns |  1,212.1 ns |  4.2265 |     - |     - |   13320 B |
| TYPE=H-CASE=B0T1P0E1D1 |  10,274.4 ns |    320.3 ns |    368.8 ns |  4.2528 |     - |     - |   13432 B |
| TYPE=H-CASE=B0T1P1E0D0 |  11,780.6 ns |    356.4 ns |    396.1 ns |  4.3952 |     - |     - |   13832 B |
| TYPE=H-CASE=B0T1P1E1D0 |  11,398.6 ns |    316.1 ns |    324.6 ns |  4.4138 |     - |     - |   13920 B |
| TYPE=H-CASE=B0T1P1E1D1 |  12,110.0 ns |    377.8 ns |    435.1 ns |  4.4273 |     - |     - |   14032 B |
| TYPE=H-CASE=B0T1P2E0D0 |  11,997.7 ns |    587.4 ns |    676.4 ns |  4.4747 |     - |     - |   14160 B |
| TYPE=H-CASE=B0T1P2E1D0 |  11,960.7 ns |    531.9 ns |    612.6 ns |  4.4996 |     - |     - |   14248 B |
| TYPE=H-CASE=B0T1P2E1D1 |  12,497.1 ns |    430.3 ns |    495.5 ns |  4.5455 |     - |     - |   14360 B |
| TYPE=H-CASE=B1T0P0E0D0 |   7,726.9 ns |    184.0 ns |    211.8 ns |  2.3866 |     - |     - |    7560 B |
| TYPE=H-CASE=B1T0P0E1D0 |  12,594.7 ns |    420.9 ns |    467.8 ns |  4.6206 |     - |     - |   14528 B |
| TYPE=H-CASE=B1T0P0E1D1 |  14,058.3 ns |    433.9 ns |    499.6 ns |  4.6710 |     - |     - |   14752 B |
| TYPE=H-CASE=B1T0P1E0D0 |   8,748.6 ns |    261.0 ns |    300.6 ns |  2.5272 |     - |     - |    7992 B |
| TYPE=H-CASE=B1T0P1E1D0 |  14,969.8 ns |    272.4 ns |    254.8 ns |  4.8772 |     - |     - |   15424 B |
| TYPE=H-CASE=B1T0P1E1D1 |  16,957.1 ns |    691.6 ns |    796.5 ns |  4.9407 |     - |     - |   15648 B |
| TYPE=H-CASE=B1T0P2E0D0 |  10,370.8 ns |    606.4 ns |    698.4 ns |  2.6088 |     - |     - |    8296 B |
| TYPE=H-CASE=B1T0P2E1D0 |  16,679.1 ns |    706.1 ns |    784.8 ns |  5.0843 |     - |     - |   16080 B |
| TYPE=H-CASE=B1T0P2E1D1 |  16,686.6 ns |    298.8 ns |    264.8 ns |  5.1706 |     - |     - |   16304 B |
| TYPE=H-CASE=B1T1P0E0D0 |  12,476.5 ns |    411.7 ns |    474.1 ns |  4.6198 |     - |     - |   14656 B |
| TYPE=H-CASE=B1T1P0E1D0 |  13,079.3 ns |    408.4 ns |    454.0 ns |  4.6037 |     - |     - |   14528 B |
| TYPE=H-CASE=B1T1P0E1D1 |  13,529.5 ns |    632.8 ns |    728.7 ns |  4.6577 |     - |     - |   14752 B |
| TYPE=H-CASE=B1T1P1E0D0 |  15,951.7 ns |    689.0 ns |    793.4 ns |  4.9274 |     - |     - |   15552 B |
| TYPE=H-CASE=B1T1P1E1D0 |  15,384.0 ns |    321.3 ns |    370.0 ns |  4.8876 |     - |     - |   15424 B |
| TYPE=H-CASE=B1T1P1E1D1 |  16,024.6 ns |    352.6 ns |    406.1 ns |  4.9702 |     - |     - |   15648 B |
| TYPE=H-CASE=B1T1P2E0D0 |  15,289.8 ns |    315.1 ns |    323.6 ns |  5.1420 |     - |     - |   16208 B |
| TYPE=H-CASE=B1T1P2E1D0 |  15,491.6 ns |    265.0 ns |    247.9 ns |  5.0642 |     - |     - |   16080 B |
| TYPE=H-CASE=B1T1P2E1D1 |  16,338.8 ns |    216.2 ns |    180.5 ns |  5.1760 |     - |     - |   16304 B |
| TYPE=S-CASE=B0T0P0E0D0 |   8,122.1 ns |    489.6 ns |    563.9 ns |  2.1155 |     - |     - |    6696 B |
| TYPE=S-CASE=B0T0P0E1D0 | 109,579.6 ns |  2,100.1 ns |  2,062.6 ns |  7.8704 |     - |     - |   25737 B |
| TYPE=S-CASE=B0T0P0E1D1 | 110,949.1 ns |  1,582.4 ns |  1,480.1 ns |  8.0935 |     - |     - |   25848 B |
| TYPE=S-CASE=B0T0P1E0D0 |   8,676.6 ns |    215.5 ns |    239.6 ns |  2.3463 |     - |     - |    7392 B |
| TYPE=S-CASE=B0T0P1E1D0 | 115,950.6 ns |  1,284.9 ns |  1,201.9 ns |  8.3955 |     - |     - |   26432 B |
| TYPE=S-CASE=B0T0P1E1D1 | 115,190.1 ns |  2,128.4 ns |  1,990.9 ns |  8.1522 |     - |     - |   26568 B |
| TYPE=S-CASE=B0T0P2E0D0 |   9,309.1 ns |    163.2 ns |    152.6 ns |  2.4609 |     - |     - |    7720 B |
| TYPE=S-CASE=B0T0P2E1D0 | 118,332.9 ns |  2,845.4 ns |  3,162.7 ns |  8.2721 |     - |     - |   26761 B |
| TYPE=S-CASE=B0T0P2E1D1 | 117,506.9 ns |  2,482.0 ns |  2,548.9 ns |  8.3333 |     - |     - |   26898 B |
| TYPE=S-CASE=B0T1P0E0D0 |  13,372.2 ns |    999.3 ns |  1,150.8 ns |  4.2994 |     - |     - |   13568 B |
| TYPE=S-CASE=B0T1P0E1D0 | 112,700.0 ns |  1,865.9 ns |  1,745.4 ns |  8.0357 |     - |     - |   25737 B |
| TYPE=S-CASE=B0T1P0E1D1 | 111,894.5 ns |  1,747.1 ns |  1,548.7 ns |  7.8671 |     - |     - |   25849 B |
| TYPE=S-CASE=B0T1P1E0D0 |  13,431.7 ns |    264.8 ns |    294.3 ns |  4.5313 |     - |     - |   14264 B |
| TYPE=S-CASE=B0T1P1E1D0 | 114,762.0 ns |  2,280.9 ns |  2,133.6 ns |  8.1522 |     - |     - |   26433 B |
| TYPE=S-CASE=B0T1P1E1D1 | 116,889.3 ns |  1,148.7 ns |  1,074.5 ns |  8.3333 |     - |     - |   26569 B |
| TYPE=S-CASE=B0T1P2E0D0 |  13,473.5 ns |    150.0 ns |    140.3 ns |  4.6198 |     - |     - |   14592 B |
| TYPE=S-CASE=B0T1P2E1D0 | 120,197.8 ns |  5,086.3 ns |  5,653.4 ns |  8.2117 |     - |     - |   26762 B |
| TYPE=S-CASE=B0T1P2E1D1 | 135,524.0 ns | 16,866.3 ns | 19,423.3 ns |  8.2364 |     - |     - |   26897 B |
| TYPE=S-CASE=B1T0P0E0D0 |   9,714.3 ns |    369.3 ns |    425.3 ns |  2.4952 |     - |     - |    7896 B |
| TYPE=S-CASE=B1T0P0E1D0 | 203,157.6 ns |  3,314.2 ns |  2,938.0 ns | 12.3355 |     - |     - |   39364 B |
| TYPE=S-CASE=B1T0P0E1D1 | 208,337.5 ns |  6,318.6 ns |  7,276.5 ns | 11.8671 |     - |     - |   39586 B |
| TYPE=S-CASE=B1T0P1E0D0 |  10,547.7 ns |    374.2 ns |    430.9 ns |  2.6420 |     - |     - |    8328 B |
| TYPE=S-CASE=B1T0P1E1D0 | 207,733.2 ns |  3,179.4 ns |  2,974.0 ns | 12.3355 |     - |     - |   40452 B |
| TYPE=S-CASE=B1T0P1E1D1 | 212,433.2 ns |  4,090.5 ns |  4,376.8 ns | 12.5000 |     - |     - |   40722 B |
| TYPE=S-CASE=B1T0P2E0D0 |  10,164.0 ns |    166.5 ns |    147.6 ns |  2.7245 |     - |     - |    8632 B |
| TYPE=S-CASE=B1T0P2E1D0 | 207,023.9 ns |  3,954.5 ns |  3,883.8 ns | 12.5000 |     - |     - |   41106 B |
| TYPE=S-CASE=B1T0P2E1D1 | 210,940.2 ns |  3,905.7 ns |  3,462.3 ns | 12.5000 |     - |     - |   41378 B |
| TYPE=S-CASE=B1T1P0E0D0 |  14,294.7 ns |    230.9 ns |    215.9 ns |  4.8293 |     - |     - |   15328 B |
| TYPE=S-CASE=B1T1P0E1D0 | 199,470.8 ns |  2,308.5 ns |  2,159.4 ns | 11.8671 |     - |     - |   39362 B |
| TYPE=S-CASE=B1T1P0E1D1 | 211,702.2 ns |  6,706.7 ns |  7,723.4 ns | 12.0192 |     - |     - |   39587 B |
| TYPE=S-CASE=B1T1P1E0D0 |  19,117.7 ns |    673.2 ns |    720.4 ns |  5.2198 |     - |     - |   16416 B |
| TYPE=S-CASE=B1T1P1E1D0 | 211,787.7 ns |  5,057.4 ns |  5,824.1 ns | 12.5000 |     - |     - |   40450 B |
| TYPE=S-CASE=B1T1P1E1D1 | 212,462.8 ns |  5,763.6 ns |  6,637.4 ns | 12.5000 |     - |     - |   40724 B |
| TYPE=S-CASE=B1T1P2E0D0 |  18,542.6 ns |    584.8 ns |    625.7 ns |  5.3842 |     - |     - |   17072 B |
| TYPE=S-CASE=B1T1P2E1D0 | 215,217.2 ns |  6,585.7 ns |  7,046.6 ns | 12.3355 |     - |     - |   41106 B |
| TYPE=S-CASE=B1T1P2E1D1 | 215,587.8 ns |  9,229.5 ns | 10,628.7 ns | 12.5000 |     - |     - |   41380 B |

// * Legends *
  Mean      : Arithmetic mean of all measurements
  Error     : Half of 99.9% confidence interval
  StdDev    : Standard deviation of all measurements
  Gen 0     : GC Generation 0 collects per 1000 operations
  Gen 1     : GC Generation 1 collects per 1000 operations
  Gen 2     : GC Generation 2 collects per 1000 operations
  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
  1 ns      : 1 Nanosecond (0.000000001 sec)

// * Diagnostic Output - MemoryDiagnoser *


// ***** BenchmarkRunner: End *****
// ** Remained 0 benchmark(s) to run **
Run time: 00:08:41 (521.47 sec), executed benchmarks: 72

Global total time: 00:08:41 (521.69 sec), executed benchmarks: 72
```

benchmarks after: 
```
BenchmarkDotNet=v0.12.0, OS=Windows 10.0.14393.3274 (1607/AnniversaryUpdate/Redstone1)
Intel Core i5-6400 CPU 2.70GHz (Skylake), 1 CPU, 4 logical and 4 physical cores
Frequency=2648431 Hz, Resolution=377.5820 ns, Timer=TSC
.NET Core SDK=3.0.100
  [Host] : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), X64 RyuJIT DEBUG

Toolchain=InProcessEmitToolchain  IterationTime=250.0000 ms  MaxIterationCount=20  
MinIterationCount=15  WarmupCount=1  

|                 Method |         Mean |        Error |       StdDev |       Median |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |-------------:|-------------:|-------------:|-------------:|--------:|------:|------:|----------:|
| TYPE=H-CASE=B0T0P0E0D0 |   6,063.3 ns |    391.50 ns |    450.85 ns |   5,960.5 ns |  1.9877 |     - |     - |    6240 B |
| TYPE=H-CASE=B0T0P0E1D0 |  10,845.2 ns |    691.25 ns |    796.05 ns |  11,211.4 ns |  4.1384 |     - |     - |   13032 B |
| TYPE=H-CASE=B0T0P0E1D1 |  11,099.7 ns |    604.58 ns |    696.23 ns |  10,917.3 ns |  4.1638 |     - |     - |   13144 B |
| TYPE=H-CASE=B0T0P1E0D0 |   6,745.4 ns |    308.95 ns |    355.79 ns |   6,614.5 ns |  2.1788 |     - |     - |    6840 B |
| TYPE=H-CASE=B0T0P1E1D0 |  11,275.2 ns |    561.23 ns |    646.31 ns |  11,345.9 ns |  4.3325 |     - |     - |   13632 B |
| TYPE=H-CASE=B0T0P1E1D1 |  11,325.0 ns |    211.84 ns |    187.79 ns |  11,338.4 ns |  4.3501 |     - |     - |   13744 B |
| TYPE=H-CASE=B0T0P2E0D0 |   6,912.4 ns |     85.25 ns |     79.74 ns |   6,901.7 ns |  2.2818 |     - |     - |    7168 B |
| TYPE=H-CASE=B0T0P2E1D0 |  12,354.0 ns |    509.10 ns |    586.27 ns |  12,380.3 ns |  4.4284 |     - |     - |   13960 B |
| TYPE=H-CASE=B0T0P2E1D1 |  12,014.1 ns |    252.62 ns |    290.92 ns |  12,002.3 ns |  4.4811 |     - |     - |   14072 B |
| TYPE=H-CASE=B0T1P0E0D0 |  10,229.7 ns |    421.80 ns |    485.75 ns |  10,187.8 ns |  4.0884 |     - |     - |   12944 B |
| TYPE=H-CASE=B0T1P0E1D0 |  10,350.7 ns |    393.94 ns |    437.86 ns |  10,339.7 ns |  4.1296 |     - |     - |   13032 B |
| TYPE=H-CASE=B0T1P0E1D1 |   9,966.7 ns |    251.00 ns |    278.99 ns |   9,873.2 ns |  4.1615 |     - |     - |   13144 B |
| TYPE=H-CASE=B0T1P1E0D0 |  12,015.5 ns |    489.49 ns |    563.69 ns |  11,915.9 ns |  4.3039 |     - |     - |   13544 B |
| TYPE=H-CASE=B0T1P1E1D0 |  11,634.6 ns |    466.75 ns |    518.79 ns |  11,482.9 ns |  4.3415 |     - |     - |   13632 B |
| TYPE=H-CASE=B0T1P1E1D1 |  13,110.1 ns |    653.70 ns |    752.80 ns |  13,247.0 ns |  4.3530 |     - |     - |   13744 B |
| TYPE=H-CASE=B0T1P2E0D0 |  13,820.9 ns |    608.16 ns |    700.36 ns |  13,718.7 ns |  4.3991 |     - |     - |   13872 B |
| TYPE=H-CASE=B0T1P2E1D0 |  12,273.8 ns |    461.74 ns |    531.74 ns |  12,189.7 ns |  4.4203 |     - |     - |   13960 B |
| TYPE=H-CASE=B0T1P2E1D1 |  11,870.7 ns |    116.07 ns |     96.92 ns |  11,866.4 ns |  4.4476 |     - |     - |   14072 B |
| TYPE=H-CASE=B1T0P0E0D0 |   7,151.6 ns |    102.64 ns |     96.01 ns |   7,138.4 ns |  2.3034 |     - |     - |    7272 B |
| TYPE=H-CASE=B1T0P0E1D0 |  12,900.7 ns |    587.02 ns |    652.47 ns |  12,763.4 ns |  4.5311 |     - |     - |   14240 B |
| TYPE=H-CASE=B1T0P0E1D1 |  14,178.9 ns |  1,126.51 ns |  1,297.29 ns |  13,975.6 ns |  4.5856 |     - |     - |   14464 B |
| TYPE=H-CASE=B1T0P1E0D0 |   9,304.6 ns |    723.50 ns |    833.18 ns |   9,120.7 ns |  2.4256 |     - |     - |    7704 B |
| TYPE=H-CASE=B1T0P1E1D0 |  15,216.1 ns |    242.32 ns |    226.66 ns |  15,231.6 ns |  4.7937 |     - |     - |   15136 B |
| TYPE=H-CASE=B1T0P1E1D1 |  17,193.6 ns |  1,719.85 ns |  1,980.58 ns |  16,130.0 ns |  4.8710 |     - |     - |   15360 B |
| TYPE=H-CASE=B1T0P2E0D0 |   8,565.2 ns |    146.82 ns |    137.34 ns |   8,579.2 ns |  2.5375 |     - |     - |    8008 B |
| TYPE=H-CASE=B1T0P2E1D0 |  15,407.3 ns |    293.23 ns |    287.99 ns |  15,443.2 ns |  5.0150 |     - |     - |   15792 B |
| TYPE=H-CASE=B1T0P2E1D1 |  16,600.6 ns |    205.73 ns |    182.37 ns |  16,572.5 ns |  5.0551 |     - |     - |   16016 B |
| TYPE=H-CASE=B1T1P0E0D0 |  12,102.4 ns |    195.72 ns |    173.50 ns |  12,119.6 ns |  4.5351 |     - |     - |   14368 B |
| TYPE=H-CASE=B1T1P0E1D0 |  12,220.1 ns |    229.36 ns |    235.54 ns |  12,177.0 ns |  4.5163 |     - |     - |   14240 B |
| TYPE=H-CASE=B1T1P0E1D1 |  12,988.5 ns |    263.01 ns |    302.88 ns |  13,028.6 ns |  4.6053 |     - |     - |   14464 B |
| TYPE=H-CASE=B1T1P1E0D0 |  15,349.4 ns |    661.41 ns |    735.15 ns |  15,379.4 ns |  4.8511 |     - |     - |   15264 B |
| TYPE=H-CASE=B1T1P1E1D0 |  14,786.8 ns |    289.44 ns |    284.27 ns |  14,714.2 ns |  4.7714 |     - |     - |   15136 B |
| TYPE=H-CASE=B1T1P1E1D1 |  16,141.1 ns |    304.26 ns |    298.82 ns |  16,108.6 ns |  4.8582 |     - |     - |   15360 B |
| TYPE=H-CASE=B1T1P2E0D0 |  16,937.0 ns |    921.62 ns |  1,061.34 ns |  17,301.3 ns |  5.0127 |     - |     - |   15920 B |
| TYPE=H-CASE=B1T1P2E1D0 |  15,992.7 ns |    802.48 ns |    924.13 ns |  15,556.4 ns |  5.0315 |     - |     - |   15792 B |
| TYPE=H-CASE=B1T1P2E1D1 |  19,159.2 ns |  1,373.09 ns |  1,581.25 ns |  18,885.6 ns |  5.0766 |     - |     - |   16016 B |
| TYPE=S-CASE=B0T0P0E0D0 |   7,247.6 ns |    361.61 ns |    416.43 ns |   7,457.9 ns |  2.0361 |     - |     - |    6408 B |
| TYPE=S-CASE=B0T0P0E1D0 | 125,141.6 ns |  6,312.56 ns |  7,016.40 ns | 124,723.9 ns |  8.1107 |     - |     - |   25448 B |
| TYPE=S-CASE=B0T0P0E1D1 | 116,060.4 ns |  3,874.81 ns |  4,462.24 ns | 115,294.8 ns |  7.9787 |     - |     - |   25560 B |
| TYPE=S-CASE=B0T0P1E0D0 |   8,954.4 ns |    574.49 ns |    661.59 ns |   8,701.8 ns |  2.2357 |     - |     - |    7104 B |
| TYPE=S-CASE=B0T0P1E1D0 | 117,146.1 ns |  3,085.34 ns |  3,301.28 ns | 116,122.0 ns |  7.9291 |     - |     - |   26144 B |
| TYPE=S-CASE=B0T0P1E1D1 | 122,139.1 ns |  2,616.03 ns |  2,907.71 ns | 122,316.3 ns |  8.3008 |     - |     - |   26280 B |
| TYPE=S-CASE=B0T0P2E0D0 |   9,552.3 ns |    536.62 ns |    617.97 ns |   9,563.2 ns |  2.3637 |     - |     - |    7432 B |
| TYPE=S-CASE=B0T0P2E1D0 | 123,384.4 ns |  3,911.11 ns |  4,504.04 ns | 123,038.2 ns |  8.1731 |     - |     - |   26472 B |
| TYPE=S-CASE=B0T0P2E1D1 | 121,877.0 ns |  3,604.12 ns |  3,856.37 ns | 120,845.8 ns |  8.0492 |     - |     - |   26608 B |
| TYPE=S-CASE=B0T1P0E0D0 |  11,634.3 ns |  1,139.12 ns |  1,266.13 ns |  11,155.2 ns |  4.1958 |     - |     - |   13280 B |
| TYPE=S-CASE=B0T1P0E1D0 | 112,806.4 ns |  1,118.97 ns |  1,046.68 ns | 113,145.7 ns |  8.0357 |     - |     - |   25448 B |
| TYPE=S-CASE=B0T1P0E1D1 | 113,747.8 ns |  2,729.85 ns |  3,034.23 ns | 113,544.3 ns |  7.6993 |     - |     - |   25560 B |
| TYPE=S-CASE=B0T1P1E0D0 |  13,347.8 ns |    280.46 ns |    288.01 ns |  13,299.6 ns |  4.4529 |     - |     - |   13976 B |
| TYPE=S-CASE=B0T1P1E1D0 | 117,794.7 ns |  2,246.09 ns |  2,306.57 ns | 118,171.0 ns |  8.2721 |     - |     - |   26144 B |
| TYPE=S-CASE=B0T1P1E1D1 | 118,948.1 ns |  2,358.26 ns |  2,523.32 ns | 119,170.8 ns |  7.9887 |     - |     - |   26280 B |
| TYPE=S-CASE=B0T1P2E0D0 |  13,260.2 ns |    278.76 ns |    286.27 ns |  13,202.7 ns |  4.5474 |     - |     - |   14304 B |
| TYPE=S-CASE=B0T1P2E1D0 | 130,125.7 ns |  4,577.69 ns |  5,271.67 ns | 130,934.8 ns |  8.3955 |     - |     - |   26472 B |
| TYPE=S-CASE=B0T1P2E1D1 | 122,596.4 ns |  5,144.47 ns |  5,924.38 ns | 122,051.8 ns |  8.4325 |     - |     - |   26608 B |
| TYPE=S-CASE=B1T0P0E0D0 |   9,967.6 ns |    757.05 ns |    871.82 ns |   9,630.2 ns |  2.3888 |     - |     - |    7608 B |
| TYPE=S-CASE=B1T0P0E1D0 | 205,508.7 ns |  2,628.05 ns |  2,458.28 ns | 206,229.0 ns | 12.3355 |     - |     - |   39072 B |
| TYPE=S-CASE=B1T0P0E1D1 | 208,188.7 ns |  5,309.09 ns |  6,113.95 ns | 207,234.3 ns | 12.3355 |     - |     - |   39296 B |
| TYPE=S-CASE=B1T0P1E0D0 |   9,874.5 ns |    194.99 ns |    216.73 ns |   9,876.0 ns |  2.5535 |     - |     - |    8040 B |
| TYPE=S-CASE=B1T0P1E1D0 | 215,803.7 ns |  4,300.88 ns |  4,224.04 ns | 214,983.7 ns | 12.6689 |     - |     - |   40160 B |
| TYPE=S-CASE=B1T0P1E1D1 | 217,114.0 ns |  4,224.72 ns |  4,520.40 ns | 217,914.7 ns | 12.1528 |     - |     - |   40432 B |
| TYPE=S-CASE=B1T0P2E0D0 |  10,831.3 ns |    299.60 ns |    333.01 ns |  10,760.2 ns |  2.6560 |     - |     - |    8344 B |
| TYPE=S-CASE=B1T0P2E1D0 | 212,793.8 ns |  2,506.42 ns |  2,092.97 ns | 212,500.0 ns | 12.1528 |     - |     - |   40816 B |
| TYPE=S-CASE=B1T0P2E1D1 | 215,062.4 ns |  4,360.63 ns |  5,021.71 ns | 215,090.9 ns | 12.6689 |     - |     - |   41088 B |
| TYPE=S-CASE=B1T1P0E0D0 |  16,041.1 ns |  1,160.50 ns |  1,336.44 ns |  15,475.7 ns |  4.7348 |     - |     - |   15040 B |
| TYPE=S-CASE=B1T1P0E1D0 | 238,426.4 ns | 29,232.18 ns | 33,663.82 ns | 213,146.6 ns | 12.1753 |     - |     - |   39072 B |
| TYPE=S-CASE=B1T1P0E1D1 | 203,532.3 ns |  3,829.33 ns |  3,581.95 ns | 203,395.9 ns | 12.5000 |     - |     - |   39296 B |
| TYPE=S-CASE=B1T1P1E0D0 |  17,964.6 ns |    327.50 ns |    306.34 ns |  17,943.8 ns |  5.0790 |     - |     - |   16128 B |
| TYPE=S-CASE=B1T1P1E1D0 | 208,092.5 ns |  1,534.64 ns |  1,435.51 ns | 207,754.8 ns | 12.5000 |     - |     - |   40160 B |
| TYPE=S-CASE=B1T1P1E1D1 | 216,470.0 ns |  4,221.00 ns |  4,691.63 ns | 217,082.8 ns | 12.8425 |     - |     - |   40432 B |
| TYPE=S-CASE=B1T1P2E0D0 |  18,315.1 ns |    276.44 ns |    245.06 ns |  18,280.7 ns |  5.2879 |     - |     - |   16784 B |
| TYPE=S-CASE=B1T1P2E1D0 | 214,166.7 ns |  4,361.01 ns |  5,022.15 ns | 214,760.6 ns | 12.8425 |     - |     - |   40816 B |
| TYPE=S-CASE=B1T1P2E1D1 | 209,528.0 ns |  2,104.07 ns |  1,865.21 ns | 209,418.3 ns | 12.3355 |     - |     - |   41088 B |

// * Legends *
  Mean      : Arithmetic mean of all measurements
  Error     : Half of 99.9% confidence interval
  StdDev    : Standard deviation of all measurements
  Median    : Value separating the higher half of all measurements (50th percentile)
  Gen 0     : GC Generation 0 collects per 1000 operations
  Gen 1     : GC Generation 1 collects per 1000 operations
  Gen 2     : GC Generation 2 collects per 1000 operations
  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
  1 ns      : 1 Nanosecond (0.000000001 sec)

// * Diagnostic Output - MemoryDiagnoser *


// ***** BenchmarkRunner: End *****
// ** Remained 0 benchmark(s) to run **
Run time: 00:08:45 (525.06 sec), executed benchmarks: 72

Global total time: 00:08:45 (525.44 sec), executed benchmarks: 72
```